### PR TITLE
fix: use Darwin binaries when targeting iOS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,7 +17,7 @@ fn link_dobby() {
     let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
     let os_dir = match target_os.as_str() {
-        "macos" => "darwin",
+        "macos" | "ios" => "darwin",
         _ => &target_os,
     };
     let arch_dir = match target_arch.as_str() {


### PR DESCRIPTION
Thanks for `dobby-sys` and `dobby-rs`, they're great crates!

Previously `build.rs` used the target OS name for the name of the library folder, which caused the build to fail as there is no `ios` library path in `dobby_static`. I've modified the build script to redirect `ios` to `darwin` (as was already done for `macos`), so the build now succeeds.